### PR TITLE
Update kinto-redis storage tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.egg-info/
 *.egg
 .venv
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-python: 3.5
+python: 3.6
 services: redis-server
 env:
-    - TOX_ENV=py35
+    - TOX_ENV=py36
     - TOX_ENV=kinto-master
     - TOX_ENV=flake8
 install:
@@ -15,6 +15,6 @@ after_success:
     - coveralls
 matrix:
   include:
-    - python: 3.6
+    - python: 3.5
       env:
-        - TOX_ENV=py36
+        - TOX_ENV=py35

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update storage tests with new Kinto 8.x features.
 
 
 1.2.0 (2017-08-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
-- Update storage tests with new Kinto 9.x features.
+- Update storage tests with new Kinto 9.x features. (#13)
 
 
 1.2.0 (2017-08-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
-- Update storage tests with new Kinto 8.x features.
+- Update storage tests with new Kinto 9.x features.
 
 
 1.2.0 (2017-08-17)

--- a/kinto_redis/storage.py
+++ b/kinto_redis/storage.py
@@ -94,11 +94,11 @@ class Storage(MemoryBasedStorage):
         if self.readonly:
             error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
             raise exceptions.BackendError(message=error_msg)
-        return self._bump_timestamp(collection_id, parent_id)
+        return self._bump_and_store_timestamp(collection_id, parent_id)
 
     @wrap_redis_error
-    def _bump_timestamp(self, collection_id, parent_id, record=None,
-                        modified_field=None, last_modified=None):
+    def _bump_and_store_timestamp(self, collection_id, parent_id, record=None,
+                                  modified_field=None, last_modified=None):
 
         key = '{0}.{1}.timestamp'.format(collection_id, parent_id)
         while 1:
@@ -108,7 +108,7 @@ class Storage(MemoryBasedStorage):
                     current_collection_timestamp = int(pipe.get(key) or 0)
                     pipe.multi()
 
-                    current, collection_timestamp = self._manage_collection_timestamp(
+                    current, collection_timestamp = self.bump_timestamp(
                         current_collection_timestamp,
                         record, modified_field,
                         last_modified)

--- a/kinto_redis/storage.py
+++ b/kinto_redis/storage.py
@@ -66,8 +66,9 @@ class Storage(MemoryBasedStorage):
         kinto.storage_pool_size = 50
     """
 
-    def __init__(self, client, *args, **kwargs):
+    def __init__(self, client, *args, readonly=False, **kwargs):
         super(Storage, self).__init__(*args, **kwargs)
+        self.readonly = readonly
         self._client = client
 
     @property
@@ -90,6 +91,9 @@ class Storage(MemoryBasedStorage):
             '{0}.{1}.timestamp'.format(collection_id, parent_id))
         if timestamp:
             return int(timestamp)
+        if self.readonly:
+            error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
+            raise exceptions.BackendError(message=error_msg)
         return self._bump_timestamp(collection_id, parent_id)
 
     @wrap_redis_error
@@ -101,32 +105,13 @@ class Storage(MemoryBasedStorage):
             with self._client.pipeline() as pipe:
                 try:
                     pipe.watch(key)
-                    previous = pipe.get(key)
+                    current_collection_timestamp = int(pipe.get(key) or 0)
                     pipe.multi()
-                    # XXX factorize code from memory and redis backends.
-                    is_specified = (record is not None and
-                                    modified_field in record or
-                                    last_modified is not None)
-                    if is_specified:
-                        # If there is a timestamp in the new record,
-                        # try to use it.
-                        if last_modified is not None:
-                            current = last_modified
-                        else:
-                            current = record[modified_field]
-                    else:
-                        current = utils.msec_time()
 
-                    if previous and int(previous) >= current:
-                        collection_timestamp = int(previous) + 1
-                    else:
-                        collection_timestamp = current
-
-                    # Return the newly generated timestamp as the current one
-                    # only if nothing else was specified.
-                    is_equal = previous and int(previous) == current
-                    if not is_specified or is_equal:
-                        current = collection_timestamp
+                    current, collection_timestamp = self._manage_collection_timestamp(
+                        current_collection_timestamp,
+                        record, modified_field,
+                        last_modified)
 
                     pipe.set(key, collection_timestamp)
                     pipe.execute()

--- a/kinto_redis/storage.py
+++ b/kinto_redis/storage.py
@@ -133,8 +133,6 @@ class Storage(MemoryBasedStorage):
             # Raise unicity error if record with same id already exists.
             try:
                 existing = self.get(collection_id, parent_id, record[id_field])
-                if ignore_conflict:
-                    return existing
                 raise exceptions.UnicityError(id_field, existing)
             except exceptions.RecordNotFoundError:
                 pass

--- a/kinto_redis/storage.py
+++ b/kinto_redis/storage.py
@@ -94,11 +94,11 @@ class Storage(MemoryBasedStorage):
         if self.readonly:
             error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
             raise exceptions.BackendError(message=error_msg)
-        return self._bump_and_store_timestamp(collection_id, parent_id)
+        return self.bump_and_store_timestamp(collection_id, parent_id)
 
     @wrap_redis_error
-    def _bump_and_store_timestamp(self, collection_id, parent_id, record=None,
-                                  modified_field=None, last_modified=None):
+    def bump_and_store_timestamp(self, collection_id, parent_id, record=None,
+                                 modified_field=None, last_modified=None):
 
         key = '{0}.{1}.timestamp'.format(collection_id, parent_id)
         while 1:

--- a/kinto_redis/storage.py
+++ b/kinto_redis/storage.py
@@ -106,13 +106,13 @@ class Storage(MemoryBasedStorage):
                 try:
                     pipe.watch(key)
                     current_collection_timestamp = int(pipe.get(key) or 0)
-                    pipe.multi()
 
                     current, collection_timestamp = self.bump_timestamp(
                         current_collection_timestamp,
                         record, modified_field,
                         last_modified)
 
+                    pipe.multi()
                     pipe.set(key, collection_timestamp)
                     pipe.execute()
                     return current

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
     CHANGELOG = f.read()
 
 REQUIREMENTS = [
-    'kinto>=9.0.0',
+    'kinto',
     'redis',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
     CHANGELOG = f.read()
 
 REQUIREMENTS = [
-    'kinto',
+    'kinto>=9.0.0',
     'redis',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
     CHANGELOG = f.read()
 
 REQUIREMENTS = [
-    'kinto>=4.0.0',
+    'kinto>=9.0.0',
     'redis',
 ]
 


### PR DESCRIPTION
Requires https://github.com/Kinto/kinto/pull/1596

```
$ .venv/bin/py.test  --cov-report term-missing --cov-fail-under 100 --cov kinto_redis
Test session starts (platform: linux, Python 3.6.5, pytest 3.5.0, pytest-sugar 0.9.1)
rootdir: /home/rhubscher/kinto/kinto-redis, inifile:
plugins: sugar-0.9.1, cov-2.5.1

 kinto_redis/tests/test_cache.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                 11% █▏        
 kinto_redis/tests/test_listeners.py ✓✓✓                                                12% █▎        
 kinto_redis/tests/test_permission.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ 36% ███▋      
 kinto_redis/tests/test_storage.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ 61% ██████▏   
                                   ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ 86% ████████▋ 
                                   ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                       100% ██████████

----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
kinto_redis/__init__.py         0      0   100%
kinto_redis/cache.py           36      0   100%
kinto_redis/listeners.py       27      0   100%
kinto_redis/permission.py     117      0   100%
kinto_redis/storage.py        201      0   100%
---------------------------------------------------------
TOTAL                         381      0   100%

Required test coverage of 100% reached. Total coverage: 100.00%

Results (4.23s):
     207 passed
```